### PR TITLE
Add asya81 and fix 2023 icon

### DIFF
--- a/_includes/2023/members.html
+++ b/_includes/2023/members.html
@@ -77,7 +77,7 @@
   </div>
 
   <div class="col-md-3 members">
-    <img src="https://pbs.twimg.com/profile_images/1421682409968336901/wLDrUvl5_400x400.jpg">
+    <img src="https://gravatar.com/avatar/dce2defbc8391d4194fbb6782064f493">
     <div class="name">asya81</div>
     <div class="profile">
       <p>初心者Rubyist</p>

--- a/_includes/2024/members.html
+++ b/_includes/2024/members.html
@@ -61,6 +61,18 @@
       <a href="https://twitter.com/sakahukamaki"><i class="fab fa-twitter fa-2x"></i></a>
     </div>
   </div>
+  <div class="col-md-3 members">
+    <img src="https://gravatar.com/avatar/dce2defbc8391d4194fbb6782064f493">
+    <div class="name">asya81</div>
+    <div class="profile">
+      <p>Rubyist 🔰</p>
+      <p>フィヨルドブートキャンプ生/自作キーボード/空手</p>
+    </div>
+    <div class="sns_icon">
+      <a href="https://twitter.com/kota_syan"><i class="fab fa-twitter fa-2x"></i></a>
+      <a href="https://github.com/asya81"><i class="fab fa-github fa-2x"></i></a>
+    </div>
+  </div>
 
   <!-- template
   <div class="col-md-3 members">


### PR DESCRIPTION
今年もお世話になります！どうぞよろしくお願いします〜 😊 

以下対応しましたので、ご確認をお願いします 🙏 
- 2024メンバーに追加
- 2023アイコンのリンク切れ対応

## 2024の画面
<img width="1440" alt="image" src="https://github.com/emorihouse/emorihouse.github.io/assets/51506307/992f4c65-ba7a-41ba-a3f9-041a3f86aa19">

## 2023の画面
![image](https://github.com/emorihouse/emorihouse.github.io/assets/51506307/73a04b3a-50e7-4fc6-ac68-b073c318e045)
